### PR TITLE
Add initial Mocha test suite

### DIFF
--- a/tests/1_contentLoader.spec.ts
+++ b/tests/1_contentLoader.spec.ts
@@ -1,0 +1,23 @@
+import './_setup';
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+
+describe('ContentLoader', () => {
+  const { ContentLoader, ContentError } = require('../src/engine/contentLoader');
+  const contentDir = path.join(__dirname, '../src/content');
+  const scenesFile = path.join(contentDir, 'scenes.json');
+
+  it('load valid sample JSON (no throw)', () => {
+    expect(() => new ContentLoader()).to.not.throw();
+  });
+
+  it('duplicate id throws ContentError', () => {
+    const original = fs.readFileSync(scenesFile, 'utf8');
+    const arr = JSON.parse(original);
+    arr.push({ ...arr[0] });
+    fs.writeFileSync(scenesFile, JSON.stringify(arr, null, 2));
+    expect(() => new ContentLoader()).to.throw(ContentError);
+    fs.writeFileSync(scenesFile, original);
+  });
+});

--- a/tests/2_gameState.spec.ts
+++ b/tests/2_gameState.spec.ts
@@ -1,0 +1,26 @@
+import './_setup';
+import { expect } from 'chai';
+
+const { ContentLoader } = require('../src/engine/contentLoader');
+const { GameState } = require('../src/engine/gameState');
+
+describe('GameState', () => {
+  const loader = new ContentLoader();
+
+  it('apply EffectChange decreases resistance', () => {
+    const state = new GameState(loader, loader.config);
+    state.setVar('resistance', 20);
+    state.apply({ change: { resistance: -10 } });
+    expect(state.getVar('resistance')).to.equal(10);
+  });
+
+  it('serialize and hydrate round-trip', () => {
+    const state = new GameState(loader, loader.config);
+    state.setVar('foo', 42);
+    const json = state.serialize();
+    const state2 = new GameState(loader, loader.config);
+    state2.hydrate(json);
+    expect(state2.serialize()).to.equal(json);
+  });
+});
+

--- a/tests/3_narrativeManager.spec.ts
+++ b/tests/3_narrativeManager.spec.ts
@@ -1,0 +1,30 @@
+import './_setup';
+import { expect } from 'chai';
+
+const { ContentLoader } = require('../src/engine/contentLoader');
+const { GameState } = require('../src/engine/gameState');
+const { NarrativeManager } = require('../src/engine/narrativeManager');
+const { CombatSystem } = require('../src/engine/combatSystem');
+
+describe('NarrativeManager', () => {
+  const loader = new ContentLoader();
+  const state = new GameState(loader, loader.config);
+  const combat = new CombatSystem();
+  const manager = new NarrativeManager(loader, state, combat);
+
+  it('choice hidden without flag', () => {
+    manager.start('A');
+    const out = manager.getSceneOutput();
+    expect(out.choices).to.have.length(0);
+  });
+
+  it('choice visible when flag set and leads to B', () => {
+    state.setVar('myFlag', true);
+    manager.start('A');
+    const out = manager.getSceneOutput();
+    expect(out.choices.map(c => c.id)).to.include('toB');
+    const res = manager.chooseOption('toB');
+    expect((res as any).text).to.equal('Scene B');
+  });
+});
+

--- a/tests/4_combatSystem.spec.ts
+++ b/tests/4_combatSystem.spec.ts
@@ -1,0 +1,18 @@
+import './_setup';
+import { expect } from 'chai';
+
+const { CombatSystem } = require('../src/engine/combatSystem');
+const { contentLoader } = require('../src/engine/contentLoader');
+const { gameState } = require('../src/engine/gameState');
+
+describe('CombatSystem', () => {
+  it('player defeats 1HP enemy and gains xp', () => {
+    const combat = new CombatSystem();
+    const start = combat.start('enemy');
+    expect(start.inCombat).to.be.true;
+    const result = combat.playerAction('atk1', 0);
+    expect(result.result).to.equal('win');
+    expect(result.xp).to.equal(1);
+  });
+});
+

--- a/tests/5_worldGenerator.spec.ts
+++ b/tests/5_worldGenerator.spec.ts
@@ -1,0 +1,25 @@
+import './_setup';
+import { expect } from 'chai';
+
+const path = require('path');
+const fs = require('fs');
+
+describe('WorldGenerator', () => {
+  it('deterministic room ids for same seed', async () => {
+    let wg = await import('../src/engine/worldGenerator');
+    let gs = await import('../src/engine/gameState');
+    wg.generateRegion('r1');
+    const ids1 = Object.keys(gs.gameState.world.regions['r1'].mutations);
+
+    delete require.cache[require.resolve('../src/engine/worldGenerator')];
+    delete require.cache[require.resolve('../src/engine/gameState')];
+    delete require.cache[require.resolve('../src/engine/contentLoader')];
+
+    wg = await import('../src/engine/worldGenerator');
+    gs = await import('../src/engine/gameState');
+    wg.generateRegion('r1');
+    const ids2 = Object.keys(gs.gameState.world.regions['r1'].mutations);
+    expect(ids2).to.deep.equal(ids1);
+  });
+});
+

--- a/tests/6_saveLoad.spec.ts
+++ b/tests/6_saveLoad.spec.ts
@@ -1,0 +1,16 @@
+import './_setup';
+import { expect } from 'chai';
+
+const { saveGame, loadGame } = require('../src/engine/saveLoad');
+const { gameState } = require('../src/engine/gameState');
+
+describe('SaveLoad', () => {
+  it('save and load restores state', () => {
+    const before = gameState.serialize();
+    saveGame(1);
+    gameState.setVar('changed', true);
+    loadGame(1);
+    expect(gameState.serialize()).to.equal(before);
+  });
+});
+

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+
+// create stub localStorage for Node
+class LocalStorageMock {
+  private store: Record<string, string> = {};
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? this.store[key]
+      : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+  clear(): void {
+    this.store = {};
+  }
+}
+
+// Attach to global if not already present
+if (!(global as any).localStorage) {
+  (global as any).localStorage = new LocalStorageMock();
+}
+
+const contentDir = path.join(__dirname, '../src/content');
+fs.mkdirSync(contentDir, { recursive: true });
+
+// minimal fixture data
+const scenes = [
+  {
+    id: 'A',
+    text: 'Scene A',
+    choices: [
+      {
+        id: 'toB',
+        text: 'To B',
+        nextScene: 'B',
+        requires: { flag: 'myFlag', value: true },
+      },
+    ],
+    schemaVersion: 1,
+  },
+  { id: 'B', text: 'Scene B', choices: [], schemaVersion: 1 },
+  { id: 'template', text: 'Template', choices: [], schemaVersion: 1 },
+];
+const skills = [
+  {
+    id: 'atk1',
+    name: 'Attack',
+    targetType: 'enemy',
+    damageType: 'physical',
+    baseDamage: 1,
+    schemaVersion: 1,
+  },
+];
+const items = [
+  { id: 'sword', name: 'Sword', type: 'weapon', schemaVersion: 1 },
+];
+const creatures = [
+  {
+    id: 'player',
+    name: 'Hero',
+    maxResistance: 10,
+    maxDesire: 10,
+    attack: 1,
+    defense: 0,
+    stamina: 1,
+    skills: ['atk1'],
+    schemaVersion: 1,
+  },
+  {
+    id: 'enemy',
+    name: 'Enemy',
+    maxResistance: 1,
+    maxDesire: 10,
+    attack: 0,
+    defense: 0,
+    stamina: 1,
+    skills: ['atk1'],
+    xpReward: 1,
+    schemaVersion: 1,
+  },
+];
+const regions = [
+  {
+    id: 'r1',
+    name: 'Region 1',
+    roomCount: 2,
+    layout: 'linear',
+    roomTemplates: ['template'],
+    schemaVersion: 1,
+  },
+];
+const config = {
+  startScene: 'A',
+  playerCharacter: 'player',
+  worldSeed: 1,
+  canSaveInCombat: true,
+  version: '1.0',
+  schemaVersion: 1,
+};
+
+function writeJSON(name: string, data: any): void {
+  fs.writeFileSync(path.join(contentDir, name), JSON.stringify(data, null, 2));
+}
+
+writeJSON('scenes.json', scenes);
+writeJSON('skills.json', skills);
+writeJSON('items.json', items);
+writeJSON('creatures.json', creatures);
+writeJSON('regions.json', regions);
+writeJSON('gameConfig.json', config);
+


### PR DESCRIPTION
## Summary
- add mocha-style tests for engine modules under `tests/`
- create `_setup.ts` fixture loader and localStorage stub

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: `mocha: not found`)*