### PR TITLE
Fix combat rewards and condition stat

### DIFF
--- a/src/engine/combatSystem.ts
+++ b/src/engine/combatSystem.ts
@@ -66,6 +66,7 @@ export class CombatSystem {
   private running = false;
   private onWin?: string;
   private onLose?: string;
+  private enemyIds: string[] = [];
 
   // ----- utilities -----
   private pickRandom<T>(arr: T[]): T {
@@ -187,13 +188,13 @@ export class CombatSystem {
     if (this.enemies.length === 0) {
       IN_COMBAT = false;
       this.running = false;
-      const xp = this.enemies.reduce((s, e) => {
-        const base = contentLoader.creatures.get(e.id);
+      const xp = this.enemyIds.reduce((s, id) => {
+        const base = contentLoader.creatures.get(id);
         return s + (base?.xpReward ?? 0);
       }, 0);
       const loot: string[] = [];
-      this.enemies.forEach((e) => {
-        const base = contentLoader.creatures.get(e.id);
+      this.enemyIds.forEach((id) => {
+        const base = contentLoader.creatures.get(id);
         base?.drops?.forEach((d) => loot.push(d));
       });
       loot.forEach((id) => gameState.apply({ addItem: id }));
@@ -249,6 +250,7 @@ export class CombatSystem {
 
     this.allies = [player, ...gameState.companions.map((c) => this.createActor(c.id))];
     this.enemies = enemiesIds.map((id) => this.createActor(id));
+    this.enemyIds = enemiesIds.slice();
     this.order = [...this.allies, ...this.enemies];
     this.turnIdx = 0;
     this.onWin = onWin;

--- a/src/engine/gameState.ts
+++ b/src/engine/gameState.ts
@@ -93,8 +93,11 @@ export class GameState {
   }
 
   private random(): number {
-    this.world.rngRuntime += 1;
-    return Math.random();
+    // Mulberry32 PRNG using rngRuntime as state
+    let t = (this.world.rngRuntime += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   }
 
   private hasItem(id: string): boolean {
@@ -122,9 +125,9 @@ export class GameState {
       const c = cond as any as { any: Condition[] };
       return c.any.some((sub) => this.check(sub));
     }
-    if ((cond as any).var !== undefined) {
-      const c = cond as any as { var: string; min?: number; max?: number };
-      const val = Number(this.vars[c.var] ?? 0);
+    if ((cond as any).stat !== undefined) {
+      const c = cond as any as { stat: string; min?: number; max?: number };
+      const val = Number(this.vars[c.stat] ?? 0);
       if (c.min !== undefined && val < c.min) return false;
       if (c.max !== undefined && val > c.max) return false;
       return true;

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -22,7 +22,7 @@ export interface ConditionAny {
 }
 
 export interface ConditionStat {
-  var: string;
+  stat: string;
   min?: number;
   max?: number;
 }

--- a/src/engine/worldGenerator.ts
+++ b/src/engine/worldGenerator.ts
@@ -121,9 +121,12 @@ export function generateRegion(regionId: string): void {
     if (region.lootPool && region.lootPool.length > 0) {
       if (mulberry32() < 0.2) {
         const item = pickRandom(region.lootPool);
+        const flag = `${roomId}_${item}_taken`;
         const take: Choice = {
+          id: flag,
           text: `take ${item}`,
-          effects: { addItem: item },
+          requires: { flag, value: false },
+          effects: [{ addItem: item }, { set: { [flag]: true } }],
         };
         scene.choices.push(take);
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
     "strict": true,
     "esModuleInterop": true,
     "moduleResolution": "node"
-  }
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- use `stat` key in condition interfaces
- update game state RNG to deterministic Mulberry32 and fix `ConditionStat`
- track enemy IDs in combat to award XP and loot
- add disappearing loot choices in world generator
- restrict tsconfig to compile only `src`

## Testing
- `tsc --noEmit`