### PR TITLE
Use seeded RNG

### DIFF
--- a/src/engine/combatSystem.ts
+++ b/src/engine/combatSystem.ts
@@ -70,7 +70,7 @@ export class CombatSystem {
 
   // ----- utilities -----
   private pickRandom<T>(arr: T[]): T {
-    return arr[Math.floor(Math.random() * arr.length)];
+    return arr[Math.floor(gameState.random() * arr.length)];
   }
 
   private createActor(id: string, equipment?: Record<string, EquippedItem>): CombatActor {
@@ -232,7 +232,7 @@ export class CombatSystem {
       enemiesIds.push(...encounter);
     } else {
       const total = encounter.randomPool.reduce((t, p) => t + (p.weight ?? 1), 0);
-      let r = Math.random() * total;
+      let r = gameState.random() * total;
       for (const p of encounter.randomPool) {
         r -= p.weight ?? 1;
         if (r <= 0) {

--- a/src/engine/gameState.ts
+++ b/src/engine/gameState.ts
@@ -92,7 +92,7 @@ export class GameState {
     this.vars[k] = current + delta;
   }
 
-  private random(): number {
+  random(): number {
     // Mulberry32 PRNG using rngRuntime as state
     let t = (this.world.rngRuntime += 0x6d2b79f5);
     t = Math.imul(t ^ (t >>> 15), t | 1);

--- a/src/engine/narrativeManager.ts
+++ b/src/engine/narrativeManager.ts
@@ -121,7 +121,7 @@ export class NarrativeManager {
 
   private pickRandom<T>(pool: RandomPool<T>[]): T {
     const total = pool.reduce((s, p) => s + (p.weight ?? 1), 0);
-    let r = Math.random() * total;
+    let r = this.state.random() * total;
     for (const p of pool) {
       r -= p.weight ?? 1;
       if (r <= 0) return p.value;

--- a/tests/7_rng.spec.ts
+++ b/tests/7_rng.spec.ts
@@ -1,0 +1,51 @@
+import './_setup';
+import { expect } from 'chai';
+
+const { ContentLoader } = require('../src/engine/contentLoader');
+const { GameState } = require('../src/engine/gameState');
+const { NarrativeManager } = require('../src/engine/narrativeManager');
+const { CombatSystem } = require('../src/engine/combatSystem');
+
+// Test deterministic behavior of seeded RNG
+
+describe('Seeded RNG', () => {
+  it('narrative pickRandom deterministic with same seed', () => {
+    const loader1 = new ContentLoader();
+    const state1 = new GameState(loader1, loader1.config);
+    const combat1 = new CombatSystem();
+    const nm1 = new NarrativeManager(loader1, state1, combat1);
+    nm1.start('R');
+    const out1 = nm1.chooseOption('toBC') as any;
+
+    const loader2 = new ContentLoader();
+    const state2 = new GameState(loader2, loader2.config);
+    const combat2 = new CombatSystem();
+    const nm2 = new NarrativeManager(loader2, state2, combat2);
+    nm2.start('R');
+    const out2 = nm2.chooseOption('toBC') as any;
+
+    expect(out1.text).to.equal(out2.text);
+  });
+
+  it('combat encounter random pool deterministic with same seed', async () => {
+    let csMod = await import('../src/engine/combatSystem');
+    let gsMod = await import('../src/engine/gameState');
+
+    const combat1 = new csMod.CombatSystem();
+    const start1 = combat1.start({ randomPool: [{ value: 'enemy' }, { value: 'enemy2' }] });
+    const e1 = start1.enemies[0].id;
+
+    delete require.cache[require.resolve('../src/engine/combatSystem')];
+    delete require.cache[require.resolve('../src/engine/gameState')];
+    delete require.cache[require.resolve('../src/engine/contentLoader')];
+
+    csMod = await import('../src/engine/combatSystem');
+    gsMod = await import('../src/engine/gameState');
+
+    const combat2 = new csMod.CombatSystem();
+    const start2 = combat2.start({ randomPool: [{ value: 'enemy' }, { value: 'enemy2' }] });
+    const e2 = start2.enemies[0].id;
+
+    expect(e2).to.equal(e1);
+  });
+});

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -44,6 +44,19 @@ const scenes = [
     schemaVersion: 1,
   },
   { id: 'B', text: 'Scene B', choices: [], schemaVersion: 1 },
+  { id: 'C', text: 'Scene C', choices: [], schemaVersion: 1 },
+  {
+    id: 'R',
+    text: 'Random',
+    choices: [
+      {
+        id: 'toBC',
+        text: 'Next',
+        nextScene: { randomPool: [{ value: 'B' }, { value: 'C' }] },
+      },
+    ],
+    schemaVersion: 1,
+  },
   { id: 'template', text: 'Template', choices: [], schemaVersion: 1 },
 ];
 const skills = [
@@ -74,6 +87,18 @@ const creatures = [
   {
     id: 'enemy',
     name: 'Enemy',
+    maxResistance: 1,
+    maxDesire: 10,
+    attack: 0,
+    defense: 0,
+    stamina: 1,
+    skills: ['atk1'],
+    xpReward: 1,
+    schemaVersion: 1,
+  },
+  {
+    id: 'enemy2',
+    name: 'Enemy2',
     maxResistance: 1,
     maxDesire: 10,
     attack: 0,


### PR DESCRIPTION
## Summary
- expose `GameState.random`
- use the seeded RNG in `narrativeManager` and `combatSystem`
- expand fixture data for RNG tests
- add tests ensuring determinism with the same seed

## Testing
- `npx mocha -r ts-node/register tests/**/*.spec.ts` *(fails: `request to https://registry.npmjs.org/mocha failed, reason: connect EHOSTUNREACH`)*