### PR TITLE
Implement companion core persistence

### DIFF
--- a/src/engine/combatSystem.ts
+++ b/src/engine/combatSystem.ts
@@ -160,6 +160,17 @@ export class CombatSystem {
     }
   }
 
+  private awardCompanionXp(xp: number): void {
+    gameState.companions.forEach((c) => {
+      c.xp += xp;
+      while (c.xpToNext && c.xp >= c.xpToNext) {
+        c.xp -= c.xpToNext;
+        c.level += 1;
+      }
+    });
+    gameState.unsummonCompanions();
+  }
+
   private processAI(actor: CombatActor): void {
     const usable = this.getUsableSkills(actor);
     if (usable.length === 0) return;
@@ -198,12 +209,14 @@ export class CombatSystem {
         base?.drops?.forEach((d) => loot.push(d));
       });
       loot.forEach((id) => gameState.apply({ addItem: id }));
+      this.awardCompanionXp(xp);
       return { result: 'win', xp, loot };
     }
     const player = this.allies[0];
     if (!player || player.resistance <= 0 || player.desire >= player.maxDesire) {
       IN_COMBAT = false;
       this.running = false;
+      this.awardCompanionXp(0);
       return { result: 'lose', xp: 0, loot: [] };
     }
 

--- a/tests/9_companionCore.spec.ts
+++ b/tests/9_companionCore.spec.ts
@@ -1,0 +1,31 @@
+import './_setup';
+import { expect } from 'chai';
+
+const { CombatSystem } = require('../src/engine/combatSystem');
+const EngineAPI = require('../src/engine/index').default;
+const { gameState } = require('../src/engine/gameState');
+const { saveGame, loadGame } = require('../src/engine/saveLoad');
+
+describe('Companion essence core', () => {
+  beforeEach(() => {
+    EngineAPI.startGame();
+  });
+
+  it('core xp persists after combat and reload', () => {
+    gameState.inventory.push({ id: 'core_enemy', qty: 1, level: 1, xp: 0, xpToNext: 1 });
+    EngineAPI.useItem('core_enemy');
+    const combat = new CombatSystem();
+    combat.start('enemy');
+    const result = combat.playerAction('atk1', 0);
+    expect(result.result).to.equal('win');
+    const core = gameState.inventory.find((i: any) => i.id === 'core_enemy');
+    expect(core.level).to.equal(2);
+    expect(core.xp).to.equal(0);
+    saveGame(1);
+    gameState.inventory = [];
+    loadGame(1);
+    const loaded = gameState.inventory.find((i: any) => i.id === 'core_enemy');
+    expect(loaded.level).to.equal(2);
+    expect(loaded.xp).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `ItemInstance` and `CompanionInstance` to track companion core data
- add `summonFromCore` and `unsummonCompanions` helpers to `gameState`
- modify `useItem` to summon companions via cores
- grant companions XP when combat ends and store it back on cores
- test essence core persistence after combat and reload

## Testing
- `npx tsc -p tsconfig.json` *(fails: command not found)*