### PR TITLE
Add mutation persistence test

### DIFF
--- a/src/engine/worldGenerator.ts
+++ b/src/engine/worldGenerator.ts
@@ -105,30 +105,38 @@ export function generateRegion(regionId: string): void {
     });
 
     if (region.encounterPool && region.encounterPool.length > 0) {
-      if (mulberry32() < 0.3) {
-        const enemy = pickRandom(region.encounterPool);
-        const auto: Choice = {
-          id: 'autoFight',
-          text: '...',
-          encounter: enemy,
-          onWin: `${roomId}_cleared`,
-          onLose: 'defeatScene',
-        };
-        scene.choices.push(auto);
+      const state =
+        gameState.world.regions[regionId]?.mutations[roomId]?.defeatedEnemies;
+      if (!state || state.size === 0) {
+        if (mulberry32() < 0.3) {
+          const enemy = pickRandom(region.encounterPool);
+          const auto: Choice = {
+            id: 'autoFight',
+            text: '...',
+            encounter: enemy,
+            onWin: `${roomId}_cleared`,
+            onLose: 'defeatScene',
+          };
+          scene.choices.push(auto);
+        }
       }
     }
 
     if (region.lootPool && region.lootPool.length > 0) {
-      if (mulberry32() < 0.2) {
-        const item = pickRandom(region.lootPool);
-        const flag = `${roomId}_${item}_taken`;
-        const take: Choice = {
-          id: flag,
-          text: `take ${item}`,
-          requires: { flag, value: false },
-          effects: [{ addItem: item }, { set: { [flag]: true } }],
-        };
-        scene.choices.push(take);
+      const state =
+        gameState.world.regions[regionId]?.mutations[roomId]?.collectedLoot;
+      if (!state || state.size === 0) {
+        if (mulberry32() < 0.2) {
+          const item = pickRandom(region.lootPool);
+          const flag = `${roomId}_${item}_taken`;
+          const take: Choice = {
+            id: flag,
+            text: `take ${item}`,
+            requires: { flag, value: false },
+            effects: [{ addItem: item }, { set: { [flag]: true } }],
+          };
+          scene.choices.push(take);
+        }
       }
     }
   });
@@ -139,10 +147,12 @@ export function generateRegion(regionId: string): void {
     mutations: {},
   };
   rooms.forEach((r) => {
-    regionState.mutations[r] = {
-      defeatedEnemies: new Set<string>(),
-      collectedLoot: new Set<string>(),
-    };
+    if (!regionState.mutations[r]) {
+      regionState.mutations[r] = {
+        defeatedEnemies: new Set<string>(),
+        collectedLoot: new Set<string>(),
+      };
+    }
   });
   gameState.world.regions[regionId] = regionState;
 

--- a/tests/5_worldGenerator.spec.ts
+++ b/tests/5_worldGenerator.spec.ts
@@ -21,5 +21,38 @@ describe('WorldGenerator', () => {
     const ids2 = Object.keys(gs.gameState.world.regions['r1'].mutations);
     expect(ids2).to.deep.equal(ids1);
   });
+
+  it('reapplies saved mutation logs on load', async () => {
+    let wg = await import('../src/engine/worldGenerator');
+    let gs = await import('../src/engine/gameState');
+    let sl = await import('../src/engine/saveLoad');
+
+    wg.generateRegion('r1');
+    const roomId = Object.keys(gs.gameState.world.regions['r1'].mutations)[0];
+
+    const mut = gs.gameState.world.regions['r1'].mutations[roomId];
+    mut.defeatedEnemies.add('enemy');
+    mut.collectedLoot.add('potion');
+
+    sl.saveGame(1);
+
+    delete require.cache[require.resolve('../src/engine/worldGenerator')];
+    delete require.cache[require.resolve('../src/engine/gameState')];
+    delete require.cache[require.resolve('../src/engine/saveLoad')];
+    delete require.cache[require.resolve('../src/engine/contentLoader')];
+
+    wg = await import('../src/engine/worldGenerator');
+    gs = await import('../src/engine/gameState');
+    sl = await import('../src/engine/saveLoad');
+    sl.loadGame(1);
+    wg.generateRegion('r1');
+
+    const scene = wg.getScene(roomId);
+    const hasEnemy = scene.choices.some((c: any) => c.id === 'autoFight');
+    const lootId = `${roomId}_potion_taken`;
+    const hasLoot = scene.choices.some((c: any) => c.id === lootId);
+    expect(hasEnemy).to.equal(false);
+    expect(hasLoot).to.equal(false);
+  });
 });
 

--- a/tests/_setup.ts
+++ b/tests/_setup.ts
@@ -162,6 +162,8 @@ const regions = [
     roomCount: 2,
     layout: 'linear',
     roomTemplates: ['template'],
+    encounterPool: ['enemy'],
+    lootPool: ['potion'],
     schemaVersion: 1,
   },
 ];


### PR DESCRIPTION
## Summary
- ensure region data keeps defeated enemy and loot info
- skip enemy and loot generation when prior mutations exist
- test that mutations persist after saving and loading

## Testing
- `tsc -p tsconfig.json`