### PR TITLE
Add combat follow-up API

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -16,6 +16,9 @@ const EngineAPI = {
   chooseOption(id: string) {
     return narrativeManager.chooseOption(id);
   },
+  combatAction(actionId: string, targetIdx: number) {
+    return narrativeManager.combatAction(actionId, targetIdx);
+  },
   useItem(id: string) {
     const invIdx = gameState.inventory.findIndex((it) => it.id === id);
     if (invIdx < 0) return;


### PR DESCRIPTION
## Summary
- track onWin/onLose in NarrativeManager when combat starts
- add NarrativeManager.combatAction
- expose EngineAPI.combatAction
- transition to the correct scene after combat ends

## Testing
- `git status --short`