### PR TITLE
Fix startGame to reset using fresh GameState

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,12 +1,13 @@
 import narrativeManager, { SceneOutput } from './narrativeManager';
-import { gameState, ItemInstance } from './gameState';
+import { gameState, GameState, ItemInstance } from './gameState';
 import { contentLoader } from './contentLoader';
 import { saveGame, loadGame } from './saveLoad';
 
 const EngineAPI = {
   startGame(): SceneOutput {
-    gameState.hydrate(gameState.serialize()); // clear vars → new game
-    gameState.world.seed = contentLoader.config.worldSeed;
+    gameState.hydrate(
+      new GameState(contentLoader, contentLoader.config).serialize(),
+    ); // clear vars → new game with defaults
     narrativeManager.start(contentLoader.config.startScene);
     return narrativeManager.getSceneOutput();
   },


### PR DESCRIPTION
## Summary
- reinitialize game state from new `GameState` instance rather than rehydrating the existing state

## Testing
- `git status --short`