### PR TITLE
Fix content validation, save guard, and combat updates

### DIFF
--- a/public/content/data.js
+++ b/public/content/data.js
@@ -4,13 +4,13 @@ export const scenes = [
         id: 'start',
         text: 'You are at the start.',
         choices: [{ id: 'end', text: 'End game', nextScene: 'end' }],
-        version: '1.0',
+        schemaVersion: 1,
     },
     {
         id: 'end',
         text: 'The end.',
         choices: [],
-        version: '1.0',
+        schemaVersion: 1,
     },
 ];
 export const skills = [
@@ -21,7 +21,7 @@ export const skills = [
         damageType: DamageType.Physical,
         baseDamage: 5,
         staminaCost: 0,
-        version: '1.0',
+        schemaVersion: 1,
     },
 ];
 export const items = [
@@ -31,7 +31,7 @@ export const items = [
         type: 'consumable',
         description: 'Heals 10.',
         onUse: { change: { resistance: 10 } },
-        version: '1.0',
+        schemaVersion: 1,
     },
 ];
 export const creatures = [
@@ -48,7 +48,7 @@ export const creatures = [
         xp: 0,
         xpToNext: 100,
         levelUpIncreases: { maxResistance: 5, attack: 1 },
-        version: '1.0',
+        schemaVersion: 1,
     },
     {
         id: 'slime',
@@ -60,7 +60,7 @@ export const creatures = [
         stamina: 5,
         skills: ['basicAttack'],
         xpReward: 10,
-        version: '1.0',
+        schemaVersion: 1,
     },
 ];
 export const regions = [
@@ -70,7 +70,7 @@ export const regions = [
         roomTemplates: ['start'],
         roomCount: 1,
         layout: 'linear',
-        version: '1.0',
+        schemaVersion: 1,
     },
 ];
 export const gameConfig = {
@@ -78,5 +78,5 @@ export const gameConfig = {
     playerCharacter: 'player',
     worldSeed: 1,
     canSaveInCombat: false,
-    version: '1.0',
+        schemaVersion: 1,
 };

--- a/public/engine/combatSystem.js
+++ b/public/engine/combatSystem.js
@@ -49,6 +49,9 @@ export class CombatSystem {
     getCurrentEnemyIds() {
         return this.enemyIds.slice();
     }
+    isActive() {
+        return this.running;
+    }
     // ----- utilities -----
     pickRandom(arr) {
         return arr[Math.floor(gameState.random() * arr.length)];
@@ -104,7 +107,7 @@ export class CombatSystem {
         const item = contentLoader.items.get(outer.id);
         return item?.protection ?? 0;
     }
-    handleDurability(actor, zone) {
+    handleDurability(actor, zone, amount = 1) {
         const items = actor.equipment[zone];
         if (!items || items.length === 0)
             return;
@@ -118,7 +121,7 @@ export class CombatSystem {
         if (!item?.protection)
             return;
         if (eq.durability !== undefined) {
-            eq.durability -= 1;
+            eq.durability -= amount;
         }
         if (eq.durability !== undefined && eq.durability <= 0) {
             items.splice(outerIdx, 1);
@@ -154,12 +157,14 @@ export class CombatSystem {
         }
         else {
             const beforeArmor = base + attacker.attack - target.defense;
-            let dmg = beforeArmor - this.armorProtection(target, zone);
+            const armor = this.armorProtection(target, zone);
+            let dmg = beforeArmor - armor;
             if (dmg < 0)
                 dmg = 0;
             target.resistance -= dmg;
-            if (dmg < beforeArmor) {
-                this.handleDurability(target, zone);
+            const blocked = Math.max(beforeArmor - dmg, 0);
+            if (blocked > 0) {
+                this.handleDurability(target, zone, blocked);
             }
         }
     }

--- a/public/engine/contentLoader.js
+++ b/public/engine/contentLoader.js
@@ -5,7 +5,7 @@ export class ContentError extends Error {
         this.name = 'ContentError';
     }
 }
-const ID_REGEX = /^[a-z][A-Za-z0-9]*$/;
+const ID_REGEX = /^[a-z][A-Za-z0-9_]*$/;
 function assert(condition, message) {
     if (!condition) {
         throw new ContentError(message);
@@ -37,7 +37,7 @@ export class ContentLoader {
         assert(Array.isArray(data), `${context} must be an array`);
         const out = [];
         data.forEach((obj, i) => {
-            assert(obj.version === '1.0', `${context}[${i}] version must be 1.0`);
+            assert(obj.schemaVersion === 1, `${context}[${i}] schemaVersion must be 1`);
             assert(ID_REGEX.test(obj.id), `${context}[${i}] invalid id '${obj.id}'`);
             out.push({ ...obj });
         });
@@ -45,7 +45,7 @@ export class ContentLoader {
     }
     loadObject(data, context) {
         assert(data && typeof data === 'object' && !Array.isArray(data), `${context} must be an object`);
-        assert(data.version === '1.0', `${context} version must be 1.0`);
+        assert(data.schemaVersion === 1, `${context} schemaVersion must be 1`);
         return data;
     }
     arrayToMap(arr, name) {

--- a/public/engine/saveLoad.js
+++ b/public/engine/saveLoad.js
@@ -1,11 +1,11 @@
-import { IN_COMBAT } from './combatSystem';
+import combatSystem from './combatSystem';
 import { gameState } from './gameState';
 import { contentLoader } from './contentLoader';
 import { generateRegion } from './worldGenerator';
 import narrativeManager from './narrativeManager';
 export function saveGame(slot = 0) {
-    if (IN_COMBAT && !contentLoader.config.canSaveInCombat)
-        throw 'CANNOT_SAVE';
+    if (combatSystem.isActive() && !contentLoader.config.canSaveInCombat)
+        throw new Error('CANNOT_SAVE_IN_COMBAT');
     const snapshot = {
         engineVersion: '1.0',
         timestamp: Date.now(),

--- a/src/content/data.ts
+++ b/src/content/data.ts
@@ -5,13 +5,13 @@ export const scenes: Scene[] = [
     id: 'start',
     text: 'You are at the start.',
     choices: [{ id: 'end', text: 'End game', nextScene: 'end' }],
-    version: '1.0',
+    schemaVersion: 1,
   },
   {
     id: 'end',
     text: 'The end.',
     choices: [],
-    version: '1.0',
+    schemaVersion: 1,
   },
 ];
 
@@ -23,7 +23,7 @@ export const skills: Skill[] = [
     damageType: DamageType.Physical,
     baseDamage: 5,
     staminaCost: 0,
-    version: '1.0',
+    schemaVersion: 1,
   },
 ];
 
@@ -34,7 +34,7 @@ export const items: Item[] = [
     type: 'consumable',
     description: 'Heals 10.',
     onUse: { change: { resistance: 10 } },
-    version: '1.0',
+    schemaVersion: 1,
   },
 ];
 
@@ -52,7 +52,7 @@ export const creatures: Creature[] = [
     xp: 0,
     xpToNext: 100,
     levelUpIncreases: { maxResistance: 5, attack: 1 },
-    version: '1.0',
+    schemaVersion: 1,
   },
   {
     id: 'slime',
@@ -64,7 +64,7 @@ export const creatures: Creature[] = [
     stamina: 5,
     skills: ['basicAttack'],
     xpReward: 10,
-    version: '1.0',
+    schemaVersion: 1,
   },
 ];
 
@@ -75,7 +75,7 @@ export const regions: Region[] = [
     roomTemplates: ['start'],
     roomCount: 1,
     layout: 'linear',
-    version: '1.0',
+    schemaVersion: 1,
   },
 ];
 
@@ -84,5 +84,5 @@ export const gameConfig: GameConfig = {
   playerCharacter: 'player',
   worldSeed: 1,
   canSaveInCombat: false,
-  version: '1.0',
+    schemaVersion: 1,
 };

--- a/src/engine/contentLoader.ts
+++ b/src/engine/contentLoader.ts
@@ -24,7 +24,7 @@ export class ContentError extends Error {
   }
 }
 
-const ID_REGEX = /^[a-z][A-Za-z0-9]*$/;
+const ID_REGEX = /^[a-z][A-Za-z0-9_]*$/;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -58,23 +58,32 @@ export class ContentLoader {
     this.validateCrossReferences();
   }
 
-  private loadArray<T extends { id: string; version: string }>(
+  private loadArray<T extends { id: string; schemaVersion: number }>(
     data: readonly T[],
     context: string,
   ): T[] {
     assert(Array.isArray(data), `${context} must be an array`);
     const out: T[] = [];
     data.forEach((obj, i) => {
-      assert(obj.version === '1.0', `${context}[${i}] version must be 1.0`);
+      assert(
+        obj.schemaVersion === 1,
+        `${context}[${i}] schemaVersion must be 1`,
+      );
       assert(ID_REGEX.test(obj.id), `${context}[${i}] invalid id '${obj.id}'`);
       out.push({ ...(obj as any) });
     });
     return out;
   }
 
-  private loadObject<T extends { version?: string }>(data: T, context: string): T {
+  private loadObject<T extends { schemaVersion?: number }>(
+    data: T,
+    context: string,
+  ): T {
     assert(data && typeof data === 'object' && !Array.isArray(data), `${context} must be an object`);
-    assert((data as any).version === '1.0', `${context} version must be 1.0`);
+    assert(
+      (data as any).schemaVersion === 1,
+      `${context} schemaVersion must be 1`,
+    );
     return data as T;
   }
 

--- a/src/engine/narrativeManager.ts
+++ b/src/engine/narrativeManager.ts
@@ -99,55 +99,58 @@ export class NarrativeManager {
 
     const choice = entry.choice;
     this.isResolving = true;
-
-    if (choice.effects) {
-      this.state.apply(choice.effects);
-      if (choice.id && choice.id.endsWith('_taken')) {
-        const room = this.parseRoom(this.currentSceneId);
-        if (room) {
-          const effects = Array.isArray(choice.effects)
-            ? choice.effects
-            : [choice.effects];
-          const add = effects.find((e) => (e as any).addItem);
-          const item = add && (add as any).addItem;
-          if (item && typeof item === 'string') {
-            const mut = this.state.world.regions[room.regionId]?.mutations[room.roomId];
-            mut?.collectedLoot.add(item);
+    try {
+      if (choice.effects) {
+        this.state.apply(choice.effects);
+        if (choice.id && choice.id.endsWith('_taken')) {
+          const room = this.parseRoom(this.currentSceneId);
+          if (room) {
+            const effects = Array.isArray(choice.effects)
+              ? choice.effects
+              : [choice.effects];
+            const add = effects.find((e) => (e as any).addItem);
+            const item = add && (add as any).addItem;
+            if (item && typeof item === 'string') {
+              const mut =
+                this.state.world.regions[room.regionId]?.mutations[room.roomId];
+              mut?.collectedLoot.add(item);
+            }
           }
         }
       }
-    }
 
-    if (choice.encounter) {
-      const loc = this.parseRoom(this.currentSceneId);
-      this.combatRoomId = loc?.roomId;
-      this.combatRegionId = loc?.regionId;
-      this.combatOnWin = choice.onWin;
-      this.combatOnLose = choice.onLose;
-      const result = this.combat.start(
-        choice.encounter,
-        choice.onWin,
-        choice.onLose,
-      );
-      this.isResolving = false;
-      return result;
-    }
 
-    let nextScene = this.currentSceneId;
-    if (choice.nextScene) {
-      if (typeof choice.nextScene === 'string') {
-        nextScene = choice.nextScene;
-      } else {
-        nextScene = this.pickRandom(choice.nextScene.randomPool);
+      if (choice.encounter) {
+        const loc = this.parseRoom(this.currentSceneId);
+        this.combatRoomId = loc?.roomId;
+        this.combatRegionId = loc?.regionId;
+        this.combatOnWin = choice.onWin;
+        this.combatOnLose = choice.onLose;
+        const result = this.combat.start(
+          choice.encounter,
+          choice.onWin,
+          choice.onLose,
+        );
+        return result;
       }
-    }
 
-    if (scene.onExit) {
-      this.state.apply(scene.onExit);
+      let nextScene = this.currentSceneId;
+      if (choice.nextScene) {
+        if (typeof choice.nextScene === 'string') {
+          nextScene = choice.nextScene;
+        } else {
+          nextScene = this.pickRandom(choice.nextScene.randomPool);
+        }
+      }
+
+      if (scene.onExit) {
+        this.state.apply(scene.onExit);
+      }
+      const out = this.start(nextScene);
+      return out;
+    } finally {
+      this.isResolving = false;
     }
-    const out = this.start(nextScene);
-    this.isResolving = false;
-    return out;
   }
 
   private pickRandom<T>(pool: RandomPool<T>[]): T {

--- a/src/engine/saveLoad.ts
+++ b/src/engine/saveLoad.ts
@@ -1,11 +1,12 @@
-import { IN_COMBAT } from './combatSystem';
+import combatSystem from './combatSystem';
 import { gameState } from './gameState';
 import { contentLoader } from './contentLoader';
 import { generateRegion } from './worldGenerator';
 import narrativeManager, { SceneOutput } from './narrativeManager';
 
 export function saveGame(slot: number = 0): void {
-  if (IN_COMBAT && !contentLoader.config.canSaveInCombat) throw 'CANNOT_SAVE';
+  if (combatSystem.isActive() && !contentLoader.config.canSaveInCombat)
+    throw new Error('CANNOT_SAVE_IN_COMBAT');
   const snapshot = {
     engineVersion: '1.0',
     timestamp: Date.now(),

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -86,7 +86,7 @@ export interface Scene {
   choices: Choice[];
   onEnter?: Effect[];
   onExit?: Effect[];
-  version: "1.0";
+  schemaVersion: 1;
 }
 
 // --- Skills ---
@@ -115,7 +115,7 @@ export interface Skill {
   cooldown?: number;
   effects?: Effect | Effect[];
   requires?: Condition | Condition[];
-  version: "1.0";
+  schemaVersion: 1;
 }
 
 // --- Items ---
@@ -136,7 +136,7 @@ export interface Item {
   level?: number;
   xp?: number;
   xpToNext?: number; // core-only
-  version: "1.0";
+  schemaVersion: 1;
 }
 
 // --- Creatures ---
@@ -157,7 +157,7 @@ export interface Creature {
   xp?: number;
   xpToNext?: number;
   levelUpIncreases?: Record<string, number>;
-  version: "1.0";
+  schemaVersion: 1;
 }
 
 // --- Regions ---
@@ -172,7 +172,7 @@ export interface Region {
   encounterPool?: string[];
   lootPool?: string[];
   randomSeed?: number;
-  version: "1.0";
+  schemaVersion: 1;
 }
 
 // --- Game Config ---
@@ -184,5 +184,5 @@ export interface GameConfig {
   companions?: string[];
   worldSeed: number;
   canSaveInCombat: boolean;
-  version: "1.0";
+  schemaVersion: 1;
 }


### PR DESCRIPTION
## Summary
- enforce `schemaVersion` and underscore IDs in content loader
- hook save game guard into combat state
- ensure durability loss when armor blocks damage
- prevent double scene transitions with `finally`
- expose `isActive()` in combat system
- update bundled content data

## Testing
- `node -v` *(fails: command not found)*