### PR TITLE
Add auto-resolve combat and demo content

### DIFF
--- a/public/content/creatures.json
+++ b/public/content/creatures.json
@@ -1,1 +1,5 @@
-[]
+[
+  { "schemaVersion":1,"id":"greenSlime","name":"Green Slime","maxResistance":12,"maxDesire":12,"attack":2,"defense":0,"stamina":3,"skills":["basicAttack"],"xpReward":8,"drops":["slimeCore"] },
+  { "schemaVersion":1,"id":"hero","name":"Hero","maxResistance":25,"maxDesire":25,"attack":4,"defense":1,"stamina":5,"skills":["basicAttack"] },
+  { "schemaVersion":1,"id":"greenSlimeCompanion","name":"Slime Buddy","maxResistance":10,"maxDesire":0,"attack":3,"defense":0,"stamina":4,"skills":["basicAttack"],"levelUpIncreases":{"maxResistance":2,"attack":1} }
+]

--- a/public/content/gameConfig.json
+++ b/public/content/gameConfig.json
@@ -1,1 +1,1 @@
-{ "schemaVersion":1,"startScene":"","worldSeed":1,"canSaveInCombat":false }
+{ "schemaVersion":1,"startScene":"intro","playerCharacter":"hero","worldSeed":1234,"canSaveInCombat":false,"version":"1.0" }

--- a/public/content/items.json
+++ b/public/content/items.json
@@ -1,1 +1,3 @@
-[]
+[
+  { "schemaVersion":1,"id":"slimeCore","name":"Slime Essence Core","type":"essenceCore","description":"A pulsing green orb.","summonCreature":"greenSlimeCompanion","level":1,"xp":0,"xpToNext":50 }
+]

--- a/public/content/regions.json
+++ b/public/content/regions.json
@@ -1,1 +1,1 @@
-[]
+[ { "schemaVersion":1,"id":"demoRegion","name":"Demo","roomCount":1,"layout":"linear","roomTemplates":["intro"] } ]

--- a/public/content/scenes.json
+++ b/public/content/scenes.json
@@ -1,1 +1,29 @@
-[]
+[
+  {
+    "schemaVersion":1,
+    "id":"intro",
+    "text":"You wake up in a misty glade. A green slime jiggles toward you.",
+    "choices":[
+      { "id":"fight", "text":"Tame the slime", "encounter":"greenSlime", "onWin":"loot", "onLose":"slimeDefeat" },
+      { "id":"leave", "text":"Retreat from the glade", "nextScene":"outro" }
+    ]
+  },
+  {
+    "schemaVersion":1,
+    "id":"loot",
+    "text":"The slime dissolves into a shimmering essence core that pulses in your palm.",
+    "choices":[
+      { "text":"Pocket the core", "effects":[{"addItem":"slimeCore"}], "nextScene":"outro" }
+    ],
+    "onEnter":[{ "change":{ "xp":10 } }]
+  },
+  {
+    "schemaVersion":1,
+    "id":"slimeDefeat",
+    "text":"Over-stimulated, you collapse in goo. Hours later you stagger upright at the glade’s edge, drenched but alive.",
+    "choices":[
+      { "text":"Shake it off and head home", "effects":[{ "set":{ "currentResistance":5,"currentDesire":0 } }], "nextScene":"outro" }
+    ]
+  },
+  { "schemaVersion":1, "id":"outro", "text":"End of demo. Thanks for playing!", "choices":[] }
+]

--- a/public/content/skills.json
+++ b/public/content/skills.json
@@ -1,1 +1,3 @@
-[]
+[
+  { "schemaVersion":1,"id":"basicAttack","name":"Strike","targetType":"enemy","damageType":"physical","baseDamage":5,"staminaCost":0 }
+]

--- a/public/engine/combatSystem.js
+++ b/public/engine/combatSystem.js
@@ -358,6 +358,18 @@ export class CombatSystem {
             activeActorId: this.order[this.turnIdx].id,
         };
     }
+
+    autoResolve(encounter) {
+        let res = this.start(encounter);
+        while (this.running) {
+            const r = this.nextTurn();
+            if (r) {
+                res = r;
+                break;
+            }
+        }
+        return res;
+    }
 }
 export const combatSystem = new CombatSystem();
 export default combatSystem;

--- a/public/engine/narrativeManager.js
+++ b/public/engine/narrativeManager.js
@@ -96,13 +96,9 @@ export class NarrativeManager {
                 }
             }
             if (choice.encounter) {
-                const loc = this.parseRoom(this.currentSceneId);
-                this.combatRoomId = loc?.roomId;
-                this.combatRegionId = loc?.regionId;
-                this.combatOnWin = choice.onWin;
-                this.combatOnLose = choice.onLose;
-                const result = this.combat.start(choice.encounter, choice.onWin, choice.onLose);
-                return result;
+                const result = this.combat.autoResolve(choice.encounter);
+                const next = result.result === 'win' ? choice.onWin : choice.onLose;
+                return this.start(next ?? this.currentSceneId);
             }
             let nextScene = this.currentSceneId;
             if (choice.nextScene) {

--- a/public/tests.js
+++ b/public/tests.js
@@ -1,14 +1,26 @@
 import { contentLoader } from './engine/contentLoader.js';
 import EngineAPI from './engine/index.js';
 
-async function runTests(){
+export async function runAll(){
   await contentLoader.loadAll();
-  const start = EngineAPI.startGame();
-  console.assert(start.text !== undefined, 'Start scene loads');
 
-  // quick dual-health combat simulation
-  // (inject dummy data into content/ for the check)
-  console.log('%cAll browser tests passed','color:green');
+  // start and choose the fight
+  let out = EngineAPI.startGame();
+  out = EngineAPI.chooseOption('fight');          // auto-resolved combat
+
+  // outcome must be either victory (loot scene) or defeat scene – both valid
+  console.assert(
+    out.text.includes('slime') || out.text.includes('goo'),
+    'Combat routed to loot OR slimeDefeat scene'
+  );
+
+  // quick save / load round-trip
+  const blob = EngineAPI.saveGame(1);
+  EngineAPI.chooseOption(out.choices[0]?.id ?? '');   // progress one step
+  EngineAPI.loadGame(1);
+  console.assert(EngineAPI.getScene().text === out.text, 'Save restored same scene');
+
+  console.log('%cBrowser tests passed (no game-over path)', 'color:green');
 }
-runTests();
 
+if(window.location.hash==='#runTests') runAll();


### PR DESCRIPTION
## Summary
- populate content JSON with demo scenes and game data
- implement `autoResolve` in the combat system
- update narrative manager to use auto-resolve encounters
- replace browser test script to cover combat and save/load

## Testing
- `git status --short`